### PR TITLE
Fix o_proj shape

### DIFF
--- a/mintext/models/llama_model.py
+++ b/mintext/models/llama_model.py
@@ -298,7 +298,7 @@ class Attention:
             ),
             'o_proj': init_normal(
                 rng(),
-                (self.config.hidden_size, self.config.hidden_size // self.num_query_groups),
+                (self.config.hidden_size, self.config.hidden_size),
                 scale=self.config.initializer_scale,
                 dtype=self.param_dtype,
             ),


### PR DESCRIPTION
On main branch, the following command would fail with a shape error:

```bash
# download dataset
wget https://huggingface.co/datasets/melikocki/preprocessed_shakespeare/resolve/main/my_dataset.json

# run training
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=. python mintext/train.py \
  --train_dataset.path=my_dataset.json \
  --train_dataset.text_processor.fields=train \
  --eval_dataset.path=my_dataset.json \
  --train_dataset.text_processor.fields=validation \
  --model.llama_model.base_model=debug \
  --model.llama_model.num_key_value_heads=1 \
  --model.llama_sharding.mesh_dim=1,1,1,1
```

The error message:

```
  File "/root/miniconda3/envs/mintext/lib/python3.10/site-packages/jax/_src/numpy/array_methods.py", line 739, in op
    return getattr(self.aval, f"_{name}")(self, *args)
  File "/root/miniconda3/envs/mintext/lib/python3.10/site-packages/jax/_src/numpy/array_methods.py", line 265, in deferring_binary_op
    return binary_op(*args)
  File "/root/miniconda3/envs/mintext/lib/python3.10/site-packages/jax/_src/numpy/ufuncs.py", line 102, in fn
    return lax_fn(x1, x2) if x1.dtype != np.bool_ else bool_lax_fn(x1, x2)
TypeError: add got incompatible shapes for broadcasting: (8, 2048, 32), (8, 2048, 128).
```

The o_proj shape was incorrectly configured. This PR fixes it.